### PR TITLE
Lightweight Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 include .env
 export
 
-.PHONY: all up setup-elk down clean fclean re
+.PHONY: all up setup-elk down clean fclean re down-elk up-elk
 
-all: up setup-elk
+all: up
 
 up:
 	docker compose up -d
+
+up-elk:
+	docker compose -f docker-compose.yaml -f docker-compose.elk.yaml up -d
+	@$(MAKE) setup-elk
 
 setup-elk:
 	@echo "waiting for elk to wek up"
@@ -57,9 +61,12 @@ setup-elk:
 down clean:
 	docker compose down
 
+down-elk:
+	docker compose -f docker-compose.yaml -f docker-compose.elk.yaml down
+
 fclean:
-	docker compose down
+	docker compose -f docker-compose.elk.yaml -f docker-compose.yaml down
 	docker system prune -a -f
-	docker compose down -v
+	docker compose -f docker-compose.elk.yaml -f docker-compose.yaml down -v
 
 re: fclean all

--- a/docker-compose.elk.yaml
+++ b/docker-compose.elk.yaml
@@ -1,0 +1,50 @@
+services:
+  backend:
+    depends_on:
+      - logstash
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.1
+    container_name: anteiku-elasticsearch
+    env_file:
+      - .env
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+  logstash:
+    image: docker.elastic.co/logstash/logstash:9.3.1
+    container_name: anteiku-logstash
+    env_file:
+      - .env
+    volumes:
+      - ./elk/logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf
+    ports:
+      - "50000:50000"
+    environment:
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - "LS_JAVA_OPTS=-Xms256m -Xmx256m"
+    depends_on:
+      - elasticsearch
+  kibana:
+    image: docker.elastic.co/kibana/kibana:9.3.1
+    container_name: anteiku-kibana
+    env_file:
+      - .env
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD}
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+
+volumes:
+  es_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,6 @@ services:
       - "5005:5005"
     depends_on:
       - postgres
-      - logstash
     env_file:
       - .env
     environment:
@@ -47,50 +46,6 @@ services:
       - REACT_APP_STUN_SERVER=${REACT_APP_STUN_SERVER}
       - REACT_APP_SIGNALING_SERVER=${REACT_APP_SIGNALING_SERVER}
     stdin_open: true
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.1
-    container_name: anteiku-elasticsearch
-    env_file:
-      - .env
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=true
-      - xpack.security.http.ssl.enabled=false
-      - xpack.security.transport.ssl.enabled=false
-      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    ports:
-      - "9200:9200"
-    volumes:
-      - es_data:/usr/share/elasticsearch/data
-  logstash:
-    image: docker.elastic.co/logstash/logstash:9.3.1
-    container_name: anteiku-logstash
-    env_file:
-      - .env
-    volumes:
-      - ./elk/logstash/logstash.conf:/usr/share/logstash/pipeline/logstash.conf
-    ports:
-      - "50000:50000"
-    environment:
-      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
-      - "LS_JAVA_OPTS=-Xms256m -Xmx256m"
-    depends_on:
-      - elasticsearch
-  kibana:
-    image: docker.elastic.co/kibana/kibana:9.3.1
-    container_name: anteiku-kibana
-    env_file:
-      - .env
-    environment:
-      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      - ELASTICSEARCH_USERNAME=kibana_system
-      - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD}
-    ports:
-      - "5601:5601"
-    depends_on:
-      - elasticsearch
 
 volumes:
   db_data:
-  es_data:


### PR DESCRIPTION
Now there are two docker-compose files one for elk, one for lightweight runs.
So the commands on the makefile are now like this:
make up : docker compose up for the project without elk
make setup-elk: this alternative to previous make all, (if you want to use elk and you don't have volume for elk you have to run it first otherwise run make up-elk)
make up-elk: just docker compose up for application and elk
make down: docker compose down ONLY for application
make down-elk: docker compose down for application and elk (if you are running elk this is how you get it down)
make fclean: docker compose down for elk and application, deletion of the volumes and clearing of cache